### PR TITLE
Explorer string support for CuPy

### DIFF
--- a/cupy/_core/_cub_reduction.pyx
+++ b/cupy/_core/_cub_reduction.pyx
@@ -362,7 +362,7 @@ cdef str _get_cub_kernel_params(tuple params, tuple arginfos):
     cdef _kernel.ParameterInfo p
     cdef _kernel._ArgInfo arginfo
     cdef lst = []
-    cdef str c_type, c_name
+    cdef str c_type, c_name, arg_preamble
     cdef int i
     assert len(params) == len(arginfos)
 

--- a/cupy/_core/_dtype.pxd
+++ b/cupy/_core/_dtype.pxd
@@ -8,3 +8,5 @@ cpdef void _raise_if_invalid_cast(
     str casting,
     argname=*
 ) except *
+
+cpdef _resolve_dtype_cast(from_dt, to)

--- a/cupy/_core/_dtype.pyx
+++ b/cupy/_core/_dtype.pyx
@@ -124,3 +124,35 @@ cpdef void _raise_if_invalid_cast(
     raise TypeError(
         f'Cannot cast {argname} from {from_dt!r} to {to_dt!r} '
         f'according to the rule \'{casting}\'')
+
+
+# TODO(sebeg): I need to make this resolution available on the NumPy side.
+cdef tuple _numpy_string_dts = (type(np.dtype("S")), type(np.dtype("U")))
+
+cpdef _resolve_dtype_cast(from_dt, to):
+    """
+    Find the result dtype of casting from_dt to `to`. `to` can be a DType
+    class or an S0 or U0 instance, in which case a special path is taken.
+
+    NumPy should make this functionality directly available.
+    """
+    if isinstance(to, np.dtype):
+        # If it is not a "flexible instance" (S0 or U0) we just return it,
+        # `to` must be the correct choice for the result.
+        if to.itemsize != 0 or not isinstance(_numpy_string_dts):
+            return to
+        # Otherwise, we may have to find the string length:
+        to = type(to)
+
+    if isinstance(from_dt, to):
+        return from_dt
+
+    if to in _numpy_string_dts:
+        res = np.promote_types(from_dt, to.type)
+        if not isinstance(res, to):
+            raise TypeError(f"Unable to cast dtype '{from_dt}' to {to}.")
+        return res
+
+    # Assume that we can just return the default until NumPy does a better job
+    # or the need arises:
+    return to()

--- a/cupy/_core/_dtype.pyx
+++ b/cupy/_core/_dtype.pyx
@@ -127,7 +127,7 @@ cpdef void _raise_if_invalid_cast(
 
 
 # TODO(sebeg): I need to make this resolution available on the NumPy side.
-cdef tuple _numpy_string_dts = (type(np.dtype("S")), type(np.dtype("U")))
+cdef tuple _numpy_string_dts = (type(numpy.dtype("S")), type(numpy.dtype("U")))
 
 cpdef _resolve_dtype_cast(from_dt, to):
     """
@@ -148,7 +148,7 @@ cpdef _resolve_dtype_cast(from_dt, to):
         return from_dt
 
     if to in _numpy_string_dts:
-        res = np.promote_types(from_dt, to.type)
+        res = numpy.promote_types(from_dt, to.type)
         if not isinstance(res, to):
             raise TypeError(f"Unable to cast dtype '{from_dt}' to {to}.")
         return res

--- a/cupy/_core/_dtype.pyx
+++ b/cupy/_core/_dtype.pyx
@@ -136,10 +136,10 @@ cpdef _resolve_dtype_cast(from_dt, to):
 
     NumPy should make this functionality directly available.
     """
-    if isinstance(to, np.dtype):
+    if isinstance(to, _dtype):
         # If it is not a "flexible instance" (S0 or U0) we just return it,
         # `to` must be the correct choice for the result.
-        if to.itemsize != 0 or not isinstance(_numpy_string_dts):
+        if to.itemsize != 0 or not isinstance(to, _numpy_string_dts):
             return to
         # Otherwise, we may have to find the string length:
         to = type(to)

--- a/cupy/_core/_fusion_trace.pyx
+++ b/cupy/_core/_fusion_trace.pyx
@@ -106,6 +106,7 @@ def _guess_routine(func, args, dtype):
 
     # Feeds dummy arguments with appropriate dtypes passed to `guess_routine`.
     dummy_args = []
+    dtypes = []
     for x in args:
         if isinstance(x, _TraceScalar):
             obj = x.dtype.type(0)
@@ -113,10 +114,11 @@ def _guess_routine(func, args, dtype):
             assert isinstance(x, _TraceArray)
             obj = core.ndarray((0,), x.dtype)
         dummy_args.append(obj)
+        dtypes.append(obj.dtype)
 
     op = func._ops.guess_routine(
         func.name, func._routine_cache, dummy_args, dtype, None)
-    in_out_dtypes = op.resolve_dtypes(tuple(dummy_args))
+    in_out_dtypes = op.resolve_dtypes(dtypes[:func.nin], dtypes[func.nin:])
     return  in_out_dtypes[0], in_out_dtypes[1], op.routine
 
 

--- a/cupy/_core/_fusion_trace.pyx
+++ b/cupy/_core/_fusion_trace.pyx
@@ -116,7 +116,7 @@ def _guess_routine(func, args, dtype):
 
     op = func._ops.guess_routine(
         func.name, func._routine_cache, dummy_args, dtype, None)
-    in_out_dtypes = op.resolve_dtypes(dummy_args)
+    in_out_dtypes = op.resolve_dtypes(tuple(dummy_args))
     return  in_out_dtypes[0], in_out_dtypes[1], op.routine
 
 

--- a/cupy/_core/_fusion_trace.pyx
+++ b/cupy/_core/_fusion_trace.pyx
@@ -118,6 +118,7 @@ def _guess_routine(func, args, dtype):
 
     op = func._ops.guess_routine(
         func.name, func._routine_cache, dummy_args, dtype, None)
+
     in_out_dtypes = op.resolve_dtypes(dtypes[:func.nin], dtypes[func.nin:])
     return  in_out_dtypes[0], in_out_dtypes[1], op.routine
 

--- a/cupy/_core/_fusion_trace.pyx
+++ b/cupy/_core/_fusion_trace.pyx
@@ -1,6 +1,6 @@
 import numpy
 
-from cupy._core import _kernel, _Op
+from cupy._core import _kernel
 from cupy._core import _reduction
 from cupy._core import core
 from cupy._core._fusion_interface import _VariableProxy
@@ -15,6 +15,7 @@ from cupy._core import _fusion_op
 from cupy._core import _fusion_optimization
 
 from cupy._core cimport internal
+from cupy._core._kernel cimport _Op
 from cupy._core._dtype cimport _raise_if_invalid_cast
 
 

--- a/cupy/_core/_fusion_trace.pyx
+++ b/cupy/_core/_fusion_trace.pyx
@@ -1,6 +1,6 @@
 import numpy
 
-from cupy._core import _kernel
+from cupy._core import _kernel, _Op
 from cupy._core import _reduction
 from cupy._core import core
 from cupy._core._fusion_interface import _VariableProxy
@@ -99,6 +99,8 @@ cdef class _ShapeConstraints:
 
 
 def _guess_routine(func, args, dtype):
+    cdef _Op op
+    cdef tuple in_out_dtypes
     assert isinstance(func, (_kernel.ufunc, _reduction._SimpleReductionKernel))
 
     # Feeds dummy arguments with appropriate dtypes passed to `guess_routine`.
@@ -113,7 +115,8 @@ def _guess_routine(func, args, dtype):
 
     op = func._ops.guess_routine(
         func.name, func._routine_cache, dummy_args, dtype, None)
-    return op.get_in_dtypes(), op.get_out_dtypes(), op.routine
+    in_out_dtypes = op.resolve_dtypes(dummy_args)
+    return  in_out_dtypes[0], in_out_dtypes[1], op.routine
 
 
 def _base(array):

--- a/cupy/_core/_gufuncs.py
+++ b/cupy/_core/_gufuncs.py
@@ -192,7 +192,7 @@ class _OpsRegister:
             ops.append(_OpsRegister._Op(ins, outs, op))
         return ops
 
-    def _determine_from_args(self, args):
+    def _determine_from_args(self, args, casting):
         n = len(args)
         in_types = tuple(arg.dtype for arg in args)
         for op in self._ops:
@@ -200,7 +200,7 @@ class _OpsRegister:
             for i in range(n):
                 it = in_types[i]
                 ot = op_types[i]
-                if not numpy.can_cast(it, ot):
+                if not numpy.can_cast(it, ot, casting=casting):
                     break
             else:
                 return op
@@ -264,7 +264,7 @@ class _OpsRegister:
                 raise RuntimeError('dtype with tuple is not yet supported')
             op = self._determine_from_dtype(dtype)
         else:
-            op = self._determine_from_args(args)
+            op = self._determine_from_args(args, casting)
 
         if op is None:
             # Should we allow op to be none?

--- a/cupy/_core/_gufuncs.py
+++ b/cupy/_core/_gufuncs.py
@@ -192,7 +192,7 @@ class _OpsRegister:
             ops.append(_OpsRegister._Op(ins, outs, op))
         return ops
 
-    def _determine_from_args(self, args, casting):
+    def _determine_from_args(self, args):
         n = len(args)
         in_types = tuple(arg.dtype for arg in args)
         for op in self._ops:
@@ -200,7 +200,7 @@ class _OpsRegister:
             for i in range(n):
                 it = in_types[i]
                 ot = op_types[i]
-                if not numpy.can_cast(it, ot, casting=casting):
+                if not numpy.can_cast(it, ot):
                     break
             else:
                 return op
@@ -264,7 +264,7 @@ class _OpsRegister:
                 raise RuntimeError('dtype with tuple is not yet supported')
             op = self._determine_from_dtype(dtype)
         else:
-            op = self._determine_from_args(args, casting)
+            op = self._determine_from_args(args)
 
         if op is None:
             # Should we allow op to be none?

--- a/cupy/_core/_kernel.pxd
+++ b/cupy/_core/_kernel.pxd
@@ -102,6 +102,9 @@ concrete dtype mapping.
         # disallowed, error_func must be set instead of routine.
         # It's called by check_valid() method.
         readonly object error_func
+        readonly object _resolution_func
+        readonly object _in_dtypes
+        readonly object _out_dtypes
 
     @staticmethod
     cdef _Op _from_type_and_routine_or_error_func(
@@ -111,9 +114,7 @@ concrete dtype mapping.
     @staticmethod
     cdef _Op from_type_and_routine(str typ, routine)
 
-    cpdef tuple get_in_dtypes(self)
-
-    cpdef tuple get_out_dtypes(self)
+    cdef tuple resolve_dtypes(self, arginfos)
 
     # Creates an op instance parsing a dtype mapping with given error function.
     @staticmethod

--- a/cupy/_core/_kernel.pxd
+++ b/cupy/_core/_kernel.pxd
@@ -12,6 +12,7 @@ cdef class ParameterInfo:
     cdef:
         readonly str name
         readonly object dtype
+        readonly str preamble
         readonly str ctype
         readonly bint raw
         readonly bint is_const
@@ -155,7 +156,7 @@ cpdef create_ufunc(name, ops, routine=*, preamble=*, doc=*,
 
 cdef tuple _get_arginfos(list args)
 
-cdef str _get_kernel_params(tuple params, tuple arginfos)
+cdef tuple _get_kernel_params(tuple params, tuple arginfos)
 
 cdef list _broadcast(list args, tuple params, bint use_size, shape_t& shape)
 

--- a/cupy/_core/_kernel.pxd
+++ b/cupy/_core/_kernel.pxd
@@ -103,8 +103,10 @@ concrete dtype mapping.
         # It's called by check_valid() method.
         readonly object error_func
         readonly object _resolution_func
-        readonly object _in_dtypes
-        readonly object _out_dtypes
+        readonly tuple _in_dtypes
+        readonly tuple _out_dtypes
+        readonly tuple _in_DType_classes
+        readonly tuple _out_DType_classes
 
     @staticmethod
     cdef _Op _from_type_and_routine_or_error_func(
@@ -114,7 +116,7 @@ concrete dtype mapping.
     @staticmethod
     cdef _Op from_type_and_routine(str typ, routine)
 
-    cdef tuple resolve_dtypes(self, tuple in_dtypes, tuple out_dtypes)
+    cdef tuple resolve_dtypes(self, list in_dtypes, list out_dtypes)
 
     # Creates an op instance parsing a dtype mapping with given error function.
     @staticmethod

--- a/cupy/_core/_kernel.pxd
+++ b/cupy/_core/_kernel.pxd
@@ -114,7 +114,7 @@ concrete dtype mapping.
     @staticmethod
     cdef _Op from_type_and_routine(str typ, routine)
 
-    cdef tuple resolve_dtypes(self, tuple arginfos)
+    cdef tuple resolve_dtypes(self, tuple in_dtypes, tuple out_dtypes)
 
     # Creates an op instance parsing a dtype mapping with given error function.
     @staticmethod

--- a/cupy/_core/_kernel.pxd
+++ b/cupy/_core/_kernel.pxd
@@ -114,7 +114,7 @@ concrete dtype mapping.
     @staticmethod
     cdef _Op from_type_and_routine(str typ, routine)
 
-    cdef tuple resolve_dtypes(self, arginfos)
+    cdef tuple resolve_dtypes(self, tuple arginfos)
 
     # Creates an op instance parsing a dtype mapping with given error function.
     @staticmethod
@@ -145,10 +145,11 @@ cdef class _Ops:
 
     cpdef _Op _guess_routine_from_dtype(self, object dtype)
 
+    cpdef extend(self, obj)
 
 cpdef create_ufunc(name, ops, routine=*, preamble=*, doc=*,
                    default_casting=*, loop_prep=*, out_ops=*,
-                   cutensor_op=*, scatter_op=*)
+                   cutensor_op=*, scatter_op=*, custom_ops=*)
 
 cdef tuple _get_arginfos(list args)
 

--- a/cupy/_core/_kernel.pxd
+++ b/cupy/_core/_kernel.pxd
@@ -71,9 +71,11 @@ cdef class _ArgInfo:
 
     cdef bint is_scalar(self)
 
-    cdef str get_c_type(self)
+    cdef tuple get_c_type(self)
 
     cdef str get_param_c_type(self, ParameterInfo p)
+
+    cdef tuple get_param_c_type_with_preamble(self, ParameterInfo p)
 
     cdef str get_c_var_name(self, ParameterInfo p)
 

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -546,11 +546,10 @@ cdef class _TypeMap:
 cdef tuple _decide_params_type_core(
         tuple in_params, tuple out_params, tuple in_args_dtype,
         tuple out_args_dtype):
-    # TODO: This needs work and cleanup.  Right now it may not even be correct.
-    print("_decide_params_type_core", in_params, out_params, in_args_dtype, out_args_dtype)
-    print("----------------")
+    # TODO: This function is pretty complex, and should probably be reorganized
+    #       a little (also to ensure correctness by making it clearer what it
+    #       does)
 
-    # TODO: The logic is still pretty likely a bit broken?!
     # typedef only once and allow output types to override input ones.
     type_dict = {}
     out_types = []
@@ -561,7 +560,7 @@ cdef tuple _decide_params_type_core(
             if a is None:
                 raise TypeError('Output arguments must be cupy arrays.')
 
-            a = numpy.dtype(a)
+            a = numpy.dtype(a) if a != "cudaTextureObject_t" else a
             out_types.append(a)
 
             if p.dtype is None:
@@ -589,7 +588,7 @@ cdef tuple _decide_params_type_core(
                 in_types.append(type_dict[p.ctype])
             continue
 
-        a = numpy.dtype(a)
+        a = numpy.dtype(a) if a != "cudaTextureObject_t" else a
         in_types.append(a)
 
         if p.dtype is None:
@@ -612,7 +611,6 @@ cdef tuple _decide_params_type_core(
                      for p in out_params]
 
     type_map = _TypeMap(tuple(sorted(type_dict.items())))
-    print(     "Result:", in_types, out_types, type_map)
     return tuple(in_types), tuple(out_types), type_map
 
 

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -582,8 +582,7 @@ cdef tuple _decide_params_type_core(
     for p, a in zip(in_params, in_args_dtype):
         if a is None:
             # The parameter is not passed as an array.
-            in_types.append(p.ctype)
-            type_dict[p.ctype] = p.ctype
+            in_types.append(p.dtype)
             continue
 
         a = numpy.dtype(a)
@@ -599,7 +598,7 @@ cdef tuple _decide_params_type_core(
                 raise TypeError(
                     'Type is mismatched. %s %s %s' % (p.name, a, p_dtype))
 
-            type_dict[ctype] = a
+            type_dict[ctype] = p_dtype
         else:
             type_dict[p.ctype] = a
         in_types.append(a)

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -597,7 +597,6 @@ cdef tuple _decide_params_type_core(
             in_types.append(a)
 
     type_map = _TypeMap(tuple(sorted(type_dict.items())))
-    print("got here!", in_types, out_types, type_map)
     return in_types, out_types, type_map
 
 
@@ -1043,7 +1042,6 @@ cdef function.Function _get_ufunc_kernel(
     for i, x in enumerate(in_types):
         str_var = 'in%d' % i
         str_type = str_var + '_type'
-        print("in types", x, arginfos[i])
         types.append((str_type, x))
         arginfo = arginfos[i]
         if arginfo.is_ndarray():
@@ -1057,7 +1055,6 @@ cdef function.Function _get_ufunc_kernel(
     for i, x in enumerate(out_types):
         str_var = 'out%d' % i
         str_type = str_var + '_type'
-        print("in types", x, arginfos[i])
         types.append((str_type, x))
         arginfo = arginfos[i + offset_out]
         op.append(f'{str_type} {str_var};')

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -222,7 +222,7 @@ cdef class _ArgInfo:
         ret._init(
             ARG_KIND_NDARRAY,
             type(arg),
-            arg.dtype.type,
+            arg.dtype,
             arg._shape.size(),
             arg._c_contiguous,
             arg._index_32_bits)

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -1043,6 +1043,7 @@ cdef function.Function _get_ufunc_kernel(
     for i, x in enumerate(in_types):
         str_var = 'in%d' % i
         str_type = str_var + '_type'
+        print("in types", x, arginfos[i])
         types.append((str_type, x))
         arginfo = arginfos[i]
         if arginfo.is_ndarray():
@@ -1056,6 +1057,7 @@ cdef function.Function _get_ufunc_kernel(
     for i, x in enumerate(out_types):
         str_var = 'out%d' % i
         str_type = str_var + '_type'
+        print("in types", x, arginfos[i])
         types.append((str_type, x))
         arginfo = arginfos[i + offset_out]
         op.append(f'{str_type} {str_var};')

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -546,6 +546,10 @@ cdef class _TypeMap:
 cdef tuple _decide_params_type_core(
         tuple in_params, tuple out_params, tuple in_args_dtype,
         tuple out_args_dtype):
+    # TODO: This needs work and cleanup.  Right now it may not even be correct.
+    print("_decide_params_type_core", in_params, out_params, in_args_dtype, out_args_dtype)
+    print("----------------")
+
     # TODO: The logic is still pretty likely a bit broken?!
     # typedef only once and allow output types to override input ones.
     type_dict = {}
@@ -607,6 +611,7 @@ cdef tuple _decide_params_type_core(
         in_types.append(a)
 
     type_map = _TypeMap(tuple(sorted(type_dict.items())))
+    print(     "Result:", in_types, out_types, type_map)
     return tuple(in_types), tuple(out_types), type_map
 
 

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -1543,7 +1543,7 @@ cdef class _Op:
         if self.error_func is not None:
             self.error_func()
 
-    cdef tuple resolve_dtypes(self, list in_args, list out_args):
+    cdef tuple resolve_dtypes(self, tuple in_args, tuple out_args):
         # In most cases, this just returns the typical dtypes matching the
         # the dtype kind (or DType class, as of now represented by the scalar).
         # For parametric DTypes, more complex handling may be necessary and

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -732,7 +732,11 @@ cdef list _get_out_args_with_params(
 
     for i, p in enumerate(out_params):
         a = out_args[i]
-        if not isinstance(a, _ndarray_base):
+        if a is None:
+            out_args[i] = _ndarray_init(
+                    cupy.ndarray, out_shape, out_types[i], None)
+            continue
+        elif not isinstance(a, _ndarray_base):
             raise TypeError(
                 'Output arguments type must be cupy.ndarray')
         arr = a

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -1500,8 +1500,8 @@ cdef class _Op:
         self.error_func = error_func
         self._resolution_func = resolution_func
         if resolution_func is None:
-            self._in_dtypes = tuple([get_dtype(t) for t in self.in_types])
-            self._out_dtypes = tuple([get_dtype(t) for t in self.out_types])
+            self._in_dtypes = tuple([get_dtype(t) for t in in_types])
+            self._out_dtypes = tuple([get_dtype(t) for t in out_types])
         else:
             # We need to use the resolution function (dtypes may depend on
             # input for parametric dtypes like strings).
@@ -1533,7 +1533,7 @@ cdef class _Op:
         if self.error_func is not None:
             self.error_func()
 
-    cdef tuple resolve_dtypes(self, arginfos):
+    cdef tuple resolve_dtypes(self, tuple arginfos):
         # In most cases, this just returns the typical dtypes matching the
         # the dtype kind (or DType class, as of now represented by the scalar).
         # For parametric DTypes, more complex handling may be necessary and
@@ -1554,6 +1554,10 @@ cdef class _Ops:
         self.ops = ops
         self.nin = nin
         self.nout = nout
+
+    cpdef extend(self, obj):
+        # TODO: Should check that all new objects are _Op instances.
+        self.ops = self.ops + tuple(obj)
 
     @staticmethod
     cdef _Ops from_tuples(object ops, routine):
@@ -1643,7 +1647,7 @@ cdef class _Ops:
 cpdef create_ufunc(name, ops, routine=None, preamble='', doc='',
                    default_casting=None, loop_prep='', out_ops=None,
                    cutensor_op=None, scatter_op=None,
-                   object custom_ops=[]):
+                   object custom_ops=()):
     ops_ = _Ops.from_tuples(ops, routine)
     ops_.extend(custom_ops)
     _out_ops = None if out_ops is None else _Ops.from_tuples(out_ops, routine)

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -546,12 +546,11 @@ cdef class _TypeMap:
 cdef tuple _decide_params_type_core(
         tuple in_params, tuple out_params, tuple in_args_dtype,
         tuple out_args_dtype):
-    # TODO: This needs work and cleanup.  Right now it may not even be correct.
-    print("_decide_params_type_core", in_params, out_params, in_args_dtype, out_args_dtype)
-    print("----------------")
-
-    type_dict = {}  # try to do each typedef only once.
+    # TODO: The logic is still pretty likely a bit broken?!
+    # typedef only once and allow output types to override input ones.
+    type_dict = {}
     out_types = []
+
     if out_args_dtype:
         assert len(out_params) == len(out_args_dtype)
         for p, a in zip(out_params, out_args_dtype):
@@ -608,7 +607,6 @@ cdef tuple _decide_params_type_core(
         in_types.append(a)
 
     type_map = _TypeMap(tuple(sorted(type_dict.items())))
-    print(     "Result:", in_types, out_types, type_map)
     return tuple(in_types), tuple(out_types), type_map
 
 

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -19,7 +19,8 @@ from cupy.cuda cimport texture
 from cupy._core cimport _accelerator
 from cupy._core cimport _carray
 from cupy._core cimport _scalar
-from cupy._core._dtype cimport get_dtype, _raise_if_invalid_cast
+from cupy._core._dtype cimport (
+        get_dtype, _raise_if_invalid_cast, _resolve_dtype_cast)
 from cupy._core._memory_range cimport may_share_bounds
 from cupy._core._scalar import get_typename as _get_typename
 from cupy._core cimport core

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -605,6 +605,12 @@ cdef tuple _decide_params_type_core(
                 raise TypeError(
                     'Type is mismatched. %s %s %s' % (p.name, a, p_dtype))
 
+    if not out_args_dtype:
+        # Out arguments types inferred from inputs (typically), the same
+        # way as inputs otherwise.
+        out_types = [type_dict[p.ctype] if p.dtype is None else p.dtype
+                     for p in out_params]
+
     type_map = _TypeMap(tuple(sorted(type_dict.items())))
     print(     "Result:", in_types, out_types, type_map)
     return tuple(in_types), tuple(out_types), type_map

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -582,7 +582,11 @@ cdef tuple _decide_params_type_core(
     for p, a in zip(in_params, in_args_dtype):
         if a is None:
             # The parameter is not passed as an array.
-            in_types.append(p.dtype)
+            if p.dtype is not None:
+                in_types.append(p.dtype)
+            else:
+                # the same "ctype" name must have been defined by an input
+                in_types.append(type_dict[p.ctype])
             continue
 
         a = numpy.dtype(a)

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -1549,7 +1549,7 @@ cdef class _Op:
         # the dtype kind (or DType class, as of now represented by the scalar).
         # For parametric DTypes, more complex handling may be necessary and
         # can be implemented by providing the resolver function.
-        if self._in_dtypes is not None:
+        if self._resolution_func is None:
             return self._in_dtypes, self._out_dtypes
 
         in_dtypes = []

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -547,7 +547,7 @@ cdef tuple _decide_params_type_core(
         tuple in_params, tuple out_params, tuple in_args_dtype,
         tuple out_args_dtype):
     # TODO: This needs work and cleanup.  Right now it may not even be correct.
-    print(_decide_params_type_core, in_params, out_params, in_args_dtype, out_args_dtype)
+    print("_decide_params_type_core", in_params, out_params, in_args_dtype, out_args_dtype)
     print("----------------")
 
     type_dict = {}  # try to do each typedef only once.
@@ -580,7 +580,13 @@ cdef tuple _decide_params_type_core(
     assert len(in_params) == len(in_args_dtype)
     in_types = []
     for p, a in zip(in_params, in_args_dtype):
-        a = numpy.dtype(a)  # a is None is possible?
+        if a is None:
+            # The parameter is not passed as an array.
+            in_types.append(p.ctype)
+            type_dict[p.ctype] = p.ctype
+            continue
+
+        a = numpy.dtype(a)
 
         if p.dtype is not None:
             p_dtype = get_dtype(p.dtype)

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -547,6 +547,8 @@ cdef tuple _decide_params_type_core(
         tuple in_params, tuple out_params, tuple in_args_dtype,
         tuple out_args_dtype):
     # TODO: This needs work and cleanup.  Right now it may not even be correct.
+    print(_decide_params_type_core, in_params, out_params, in_args_dtype, out_args_dtype)
+    print("----------------")
 
     type_dict = {}  # try to do each typedef only once.
     out_types = []
@@ -597,6 +599,7 @@ cdef tuple _decide_params_type_core(
         in_types.append(a)
 
     type_map = _TypeMap(tuple(sorted(type_dict.items())))
+    print(     "Result:", in_types, out_types, type_map)
     return tuple(in_types), tuple(out_types), type_map
 
 

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -329,6 +329,7 @@ cdef class _ArgInfo:
             # Some code paths will not use the preamble.  In most cases that is
             # probably not relevant, but when it is they can be updated.
             raise TypeError(f"Compiling for '{ctyp}' not possible here.")
+        return ctyp
 
     cdef tuple get_param_c_type_with_preamble(self, ParameterInfo p):
         # Returns the C type representation in the global function's
@@ -736,7 +737,7 @@ cdef list _get_out_args_with_params(
             out_args[i] = _ndarray_init(
                     cupy.ndarray, out_shape, out_types[i], None)
             continue
-        elif not isinstance(a, _ndarray_base):
+        if not isinstance(a, _ndarray_base):
             raise TypeError(
                 'Output arguments type must be cupy.ndarray')
         arr = a

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -562,8 +562,11 @@ cdef tuple _decide_params_type_core(
                 raise TypeError('Output arguments must be cupy arrays.')
 
             a = numpy.dtype(a)
+            out_types.append(a)
 
-            if p.dtype is not None:
+            if p.dtype is None:
+                type_dict[p.ctype] = a
+            else:
                 p_dtype = get_dtype(p.dtype)
                 if a == p_dtype:
                     ctype = p.ctype
@@ -573,12 +576,6 @@ cdef tuple _decide_params_type_core(
                 else:
                     raise TypeError(
                         'Type is mismatched. %s %s %s' % (p.name, a, p.dtype))
-
-                type_dict[ctype] = a
-            else:
-                type_dict[p.ctype] = a
-
-            out_types.append(a)
 
     assert len(in_params) == len(in_args_dtype)
     in_types = []
@@ -593,22 +590,20 @@ cdef tuple _decide_params_type_core(
             continue
 
         a = numpy.dtype(a)
+        in_types.append(a)
 
-        if p.dtype is not None:
+        if p.dtype is None:
+            type_dict[p.ctype] = a
+        else:
             p_dtype = get_dtype(p.dtype)
             if a == p_dtype:
-                ctype = p.ctype
+                pass
             elif type(a) == type(p_dtype):
                 # a is the same type, but it is parametric (i.e. string length)
-                ctype = _get_typename(a)
+                pass
             else:
                 raise TypeError(
                     'Type is mismatched. %s %s %s' % (p.name, a, p_dtype))
-
-            type_dict[ctype] = p_dtype
-        else:
-            type_dict[p.ctype] = a
-        in_types.append(a)
 
     type_map = _TypeMap(tuple(sorted(type_dict.items())))
     print(     "Result:", in_types, out_types, type_map)

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -546,6 +546,12 @@ cdef class _TypeMap:
 cdef tuple _decide_params_type_core(
         tuple in_params, tuple out_params, tuple in_args_dtype,
         tuple out_args_dtype):
+    # TODO: This step is effectively NumPy's type resolution step... Now, the
+    #       only way to do this is to do proper type resolution, there are
+    #       two problems questions: 1. NumPy doesn't make that very public yet
+    #       (partially through ufnc._resolve_descitpors!)  and 2. even if we
+    #       use NumPy, we need to map to its ufuncs? OTOH, it would make NEP 50
+    #       trivial?
     type_dict = {}  # try to do each typedef only once.
     out_types = []
     if out_args_dtype:
@@ -591,6 +597,7 @@ cdef tuple _decide_params_type_core(
             in_types.append(a)
 
     type_map = _TypeMap(tuple(sorted(type_dict.items())))
+    print("got here!", in_types, out_types, type_map)
     return in_types, out_types, type_map
 
 

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -1301,6 +1301,10 @@ cdef class ufunc:
                     raise ValueError("'out' must be a tuple of arrays")
                 out_args = out,
 
+        # Normalize outputs to a tuple of Nones:
+        if len(out_args) < self.nout:
+            out_args += (None,) * (self.nout - len(out_args))
+
         dev_id = device.get_device_id()
         in_args = _preprocess_args(dev_id, in_args, False)
         out_args = _preprocess_optional_args(dev_id, out_args, False)

--- a/cupy/_core/_kernel.pyx
+++ b/cupy/_core/_kernel.pyx
@@ -55,6 +55,7 @@ cdef str _get_simple_elementwise_kernel_code(
         tuple params, tuple arginfos, str operation, str name,
         _TypeMap type_map, str preamble, str loop_prep='', str after_loop=''):
     # No loop unrolling due to avoid 64-bit division
+    print(type_map)
     module_code = string.Template('''
     ${typedef_preamble}
     ${preamble}

--- a/cupy/_core/_reduction.pyx
+++ b/cupy/_core/_reduction.pyx
@@ -342,6 +342,9 @@ cdef class _AbstractReductionKernel:
             out_axis = _sort_axis(out_axis, strides)
 
         out_shape = _get_out_shape(a_shape, reduce_axis, out_axis, keepdims)
+
+        if not out_args:
+            out_args = [None]
         out_args = self._get_out_args(out_args, out_types, out_shape)
         ret = out_args[0]
         if ret.size == 0:
@@ -623,6 +626,8 @@ cdef class _SimpleReductionKernel(_AbstractReductionKernel):
             self.name, self._routine_cache, in_args, dtype, self._ops)
         map_expr, reduce_expr, post_map_expr, reduce_type = op.routine
 
+        # Note: In principle we need to call op.resolve_dtypes, but in
+        #       practice reductions do not exist for parametric dtypes.
         if reduce_type is None:
             reduce_type = _get_typename(op.out_types[0])
 

--- a/cupy/_core/_reduction.pyx
+++ b/cupy/_core/_reduction.pyx
@@ -49,6 +49,8 @@ cpdef str _create_reduction_function_code(
         name, block_size, reduce_type, params, arginfos, identity,
         pre_map_expr, reduce_expr, post_map_expr,
         _kernel._TypeMap type_map, input_expr, output_expr, preamble, options):
+    params_preamble, params_sig = _kernel._get_kernel_params(params, arginfos)
+
     # A (incomplete) list of internal variables:
     # _J            : the index of an element in the array
     # _block_size   : the number of threads in a block; should be power of 2
@@ -57,6 +59,7 @@ cpdef str _create_reduction_function_code(
 
     module_code = string.Template('''
 ${type_preamble}
+${params_preamble}
 ${preamble}
 #define REDUCE(a, b) (${reduce_expr})
 #define POST_MAP(a) (${post_map_expr})
@@ -112,7 +115,8 @@ extern "C" __global__ void ${name}(${params}) {
         name=name,
         block_size=block_size,
         reduce_type=reduce_type,
-        params=_kernel._get_kernel_params(params, arginfos),
+        params_preamble=params_preamble,
+        params=params_sig,
         identity=identity,
         reduce_expr=reduce_expr,
         pre_map_expr=pre_map_expr,

--- a/cupy/_core/_routines_logic.pyx
+++ b/cupy/_core/_routines_logic.pyx
@@ -68,7 +68,7 @@ def _fix_to_sctype(dtype, sctype):
     return np.dtype((sctype, length))
 
 
-def _s_copy_resolver(op, arginfo):
+def _s_cmp_resolver(op, arginfo):
     # Support only U->S and S->U casts right now
 
     in1_dtype = _fix_to_sctype(arginfo[0].dtype, op.in_types[0])
@@ -88,17 +88,23 @@ cpdef create_comparison(name, op, doc='', no_complex_dtype=True):
                'll->?', 'LL->?', 'qq->?', 'QQ->?', 'ee->?', 'ff->?', 'dd->?',
                'FF->?', 'DD->?')
 
+    if op == "==":
+        # Define the more complicated string ops, for now only `==`
+        custom_ops=[
+            # Note, mixing right now would cast, but we the code can really do
+            # without (C++ might optimize that away.)
+            _Op((np.bytes_, np.bytes_), (np.bool_,), 'out0 = in0 %s in1' % op, None, _s_cmp_resolver),
+            _Op((np.str_, np.str_), (np.bool_,), 'out0 = in0 %s in1' % op, None, _s_cmp_resolver),
+            ]
+    else:
+        custom_ops = []
+
     return create_ufunc(
         'cupy_' + name,
         ops,
         'out0 = in0 %s in1' % op,
         doc=doc,
-        custom_ops=[
-            # Note, mixing right now would cast, but we the code can really do
-            # without (C++ might optimize that away.)
-            _Op((np.bytes_, np.bytes_), (np.bool_,), 'out0 = in0 %s in1' % op, None, _s_copy_resolver),
-            _Op((np.str_, np.str_), (np.bool_,), 'out0 = in0 %s in1' % op, None, _s_copy_resolver),
-            ])
+        custom_ops=custom_ops)
 
 
 cdef _greater = create_comparison(

--- a/cupy/_core/_routines_logic.pyx
+++ b/cupy/_core/_routines_logic.pyx
@@ -56,11 +56,12 @@ cpdef create_comparison(name, op, doc='', no_complex_dtype=True):
 
     if no_complex_dtype:
         ops = ('??->?', 'bb->?', 'BB->?', 'hh->?', 'HH->?', 'ii->?', 'II->?',
-               'll->?', 'LL->?', 'qq->?', 'QQ->?', 'ee->?', 'ff->?', 'dd->?')
+               'll->?', 'LL->?', 'qq->?', 'QQ->?', 'ee->?', 'ff->?', 'dd->?',
+               'SS->?', 'UU->?')
     else:
         ops = ('??->?', 'bb->?', 'BB->?', 'hh->?', 'HH->?', 'ii->?', 'II->?',
                'll->?', 'LL->?', 'qq->?', 'QQ->?', 'ee->?', 'ff->?', 'dd->?',
-               'FF->?', 'DD->?')
+               'FF->?', 'DD->?', 'SS->?', 'UU->?')
 
     return create_ufunc(
         'cupy_' + name,

--- a/cupy/_core/_routines_logic.pyx
+++ b/cupy/_core/_routines_logic.pyx
@@ -94,6 +94,8 @@ cpdef create_comparison(name, op, doc='', no_complex_dtype=True):
         'out0 = in0 %s in1' % op,
         doc=doc,
         custom_ops=[
+            # Note, mixing right now would cast, but we the code can really do
+            # without (C++ might optimize that away.)
             _Op((np.bytes_, np.bytes_), (np.bool_,), 'out0 = in0 %s in1' % op, None, _s_copy_resolver),
             _Op((np.str_, np.str_), (np.bool_,), 'out0 = in0 %s in1' % op, None, _s_copy_resolver),
             ])

--- a/cupy/_core/_routines_logic.pyx
+++ b/cupy/_core/_routines_logic.pyx
@@ -1,4 +1,6 @@
-from cupy._core._kernel import create_ufunc
+import numpy as np
+
+from cupy._core._kernel import create_ufunc, _Op
 from cupy._core._reduction import create_reduction_func
 
 from cupy._core.core cimport _ndarray_base
@@ -52,22 +54,49 @@ cdef _any = create_reduction_func(
     'false', '')
 
 
+def _fix_to_sctype(dtype, sctype):
+    if dtype.type == sctype:
+        return dtype
+    elif dtype.kind == "S":
+        length = dtype.itemsize
+    elif dtype.kind == "U":
+        length = dtype.itemsize // 4
+    else:
+        raise ValueError(
+            "Strings can currently only be compared with strings.")
+
+    return np.dtype((sctype, length))
+
+
+def _s_copy_resolver(op, arginfo):
+    # Support only U->S and S->U casts right now
+
+    in1_dtype = _fix_to_sctype(arginfo[0].dtype, op.in_types[0])
+    in2_dtype = _fix_to_sctype(arginfo[1].dtype, op.in_types[1])
+    out_dtype = np.dtype("?")
+
+    return (in1_dtype, in2_dtype), (out_dtype,)
+
+
 cpdef create_comparison(name, op, doc='', no_complex_dtype=True):
 
     if no_complex_dtype:
         ops = ('??->?', 'bb->?', 'BB->?', 'hh->?', 'HH->?', 'ii->?', 'II->?',
-               'll->?', 'LL->?', 'qq->?', 'QQ->?', 'ee->?', 'ff->?', 'dd->?',
-               'SS->?', 'UU->?')
+               'll->?', 'LL->?', 'qq->?', 'QQ->?', 'ee->?', 'ff->?', 'dd->?')
     else:
         ops = ('??->?', 'bb->?', 'BB->?', 'hh->?', 'HH->?', 'ii->?', 'II->?',
                'll->?', 'LL->?', 'qq->?', 'QQ->?', 'ee->?', 'ff->?', 'dd->?',
-               'FF->?', 'DD->?', 'SS->?', 'UU->?')
+               'FF->?', 'DD->?')
 
     return create_ufunc(
         'cupy_' + name,
         ops,
         'out0 = in0 %s in1' % op,
-        doc=doc)
+        doc=doc,
+        custom_ops=[
+            _Op((np.bytes_, np.bytes_), (np.bool_,), 'out0 = in0 %s in1' % op, None, _s_copy_resolver),
+            _Op((np.str_, np.str_), (np.bool_,), 'out0 = in0 %s in1' % op, None, _s_copy_resolver),
+            ])
 
 
 cdef _greater = create_comparison(

--- a/cupy/_core/_scalar.pxd
+++ b/cupy/_core/_scalar.pxd
@@ -29,6 +29,7 @@ cdef class CScalar(CPointer):
     cpdef get_numpy_type(self)
 
 
+cpdef tuple get_typename_with_preamble(dtype)
 cpdef str get_typename(dtype)
 
 cdef set scalar_type_set

--- a/cupy/_core/_scalar.pyx
+++ b/cupy/_core/_scalar.pyx
@@ -101,6 +101,8 @@ cdef _setup_type_dict():
         _typenames[t] = _typenames_base[d]
         k = ord(d.kind)
         _dtype_kind_size_dict[t] = (k, d.itemsize)
+        # TODO: Also include the dtype, should probably not need this:
+        _dtype_kind_size_dict[d] = (k, d.itemsize)
     # CUDA types
     for t in ('cudaTextureObject_t',):
         _typenames[t] = t

--- a/cupy/_core/_scalar.pyx
+++ b/cupy/_core/_scalar.pyx
@@ -225,7 +225,6 @@ cdef class CScalar(CPointer):
         return ret
 
     cpdef apply_dtype(self, dtype):
-        print("Apply dtype", dtype)
         cdef Scalar* s = <Scalar*>self.ptr
         if self.kind == b'b':
             val = s.bool_

--- a/cupy/_core/_scalar.pyx
+++ b/cupy/_core/_scalar.pyx
@@ -66,11 +66,27 @@ cdef object _numpy_complex_ = numpy.complex_
 
 
 cpdef str get_typename(dtype):
+    # TODO(seberg): Maybe it would make sense to return additional includes
+    #               here to allow almost arbitray extension in the future?
+    # TODO(seberg): By default reject strings as they will lead to errors?
     if dtype is None:
         raise ValueError('dtype is None')
-    if dtype not in _typenames:
-        dtype = _dtype.get_dtype(dtype).type
-    return _typenames[dtype]
+
+    if dtype in _typenames:
+        return _typenames[dtype]
+
+    dtype = _dtype.get_dtype(dtype)
+
+    if dtype.type in _typenames:
+        return _typenames[dtype.type]
+
+    # TODO: Are these the best names for char8_t and char32_t to use?
+    if dtype.char == "S":
+        return f"NumPyString<unsigned char, {dtype.itemsize}>"
+    else:
+        return f"NumPyString<unsigned int, {dtype.itemsize // 4}>"
+
+    raise TypeError(f"Cannot compile for dtype '{dtype}'")
 
 
 cdef dict _typenames = {}

--- a/cupy/_core/_scalar.pyx
+++ b/cupy/_core/_scalar.pyx
@@ -225,6 +225,7 @@ cdef class CScalar(CPointer):
         return ret
 
     cpdef apply_dtype(self, dtype):
+        print("Apply dtype", dtype)
         cdef Scalar* s = <Scalar*>self.ptr
         if self.kind == b'b':
             val = s.bool_

--- a/cupy/_core/_ufuncs.py
+++ b/cupy/_core/_ufuncs.py
@@ -1,9 +1,34 @@
-from cupy._core._kernel import create_ufunc
+from cupy._core._kernel import create_ufunc, _Op
+
+
+def _fix_to_sctype(dtype, sctype):
+    if dtype.type == sctype:
+        return dtype
+    elif dtype.kind == "S":
+        length = dtype.itemsize
+    elif dtype.kind == "U":
+        length = dtype.itemsize // 4
+    else:
+        raise ValueError("CuPy currently only supports string conversions.")
+
+    return np.dtype((sctype, length))
+
+def _s_copy_resolver(op, arginfo):
+    # Support only U->S and S->U casts right now
+    sctype = op.in_type[0]
+
+    in_dtype = _fix_to_sctype(arginfo[0].dtype, sctype)
+    out_dtype = in_dtype  # could call _fix_to_sctype just to sanity check
+
+    return in_dtype, out_dtype
 
 
 elementwise_copy = create_ufunc(
     'cupy_copy',
     ('?->?', 'b->b', 'B->B', 'h->h', 'H->H', 'i->i', 'I->I', 'l->l', 'L->L',
-     'q->q', 'Q->Q', 'e->e', 'f->f', 'd->d', 'F->F', 'D->D', 'S->S', 'U->U'),
+     'q->q', 'Q->Q', 'e->e', 'f->f', 'd->d', 'F->F', 'D->D'),
     'out0 = in0',
-    default_casting='unsafe')
+    default_casting='unsafe', custom_ops=[
+        _Op((np.bytes_,), (np.bytes_,), "out0 = in0", None, _s_copy_resolver),
+        _Op((np.str_,), (np.str_,), "out0 = in0", None, _s_copy_resolver),
+    ])

--- a/cupy/_core/_ufuncs.py
+++ b/cupy/_core/_ufuncs.py
@@ -15,22 +15,10 @@ def _fix_to_sctype(dtype, sctype):
     return np.dtype((sctype, length))
 
 def _s_copy_resolver(op, in_dtypes, out_dtypes):
-    # Support only U->S and S->U casts right now
+    # The result must have the same length as the input (it may be cast
+    # after the copy no-op)
     sctype = op.in_types[0]
-
-    in_dtype = _fix_to_sctype(in_dtypes[0], sctype)
-    out_dtype = in_dtype  # could call _fix_to_sctype just to sanity check
-
-    return (in_dtype,), (out_dtype,)
-
-def _double_cast_resolver(op, arginfo):
-    # Support only U->S and S->U casts right now
-    sctype = op.in_types[1]
-
-    in_dtype = _fix_to_sctype(arginfo[0].dtype, sctype)
-    out_dtype = np.dtype((sctype, 32))
-
-    return (arginfo[0].dtype,), (out_dtype,)
+    return (in_dtype,), (in_dtype,)
 
 elementwise_copy = create_ufunc(
     'cupy_copy',
@@ -38,12 +26,8 @@ elementwise_copy = create_ufunc(
      'q->q', 'Q->Q', 'e->e', 'f->f', 'd->d', 'F->F', 'D->D'),
     'out0 = in0',
     default_casting='unsafe', custom_ops=[
-        # NOTE: Casts probably need to be handled differently somewhere.
-        #       the promotion here may get awkward, and we also may need the
-        #       resolution more explicit in some cases, I suspect.
-        #       (i.e. for composing some things.  OTOH, it may be low prio)
-        _Op((np.double,), (np.bytes_,), "out0 = in0", None, _double_cast_resolver),
-        _Op((np.double,), (np.str_,), "out0 = in0", None, _double_cast_resolver),
+        # It should be noted that casting isn't actually handled here, rather
+        # the inner-loop of "copy" is effectively a no-op.
         _Op((np.bytes_,), (np.bytes_,), "out0 = in0", None, _s_copy_resolver),
         _Op((np.str_,), (np.str_,), "out0 = in0", None, _s_copy_resolver),
     ])

--- a/cupy/_core/_ufuncs.py
+++ b/cupy/_core/_ufuncs.py
@@ -1,3 +1,4 @@
+import numpy as np
 from cupy._core._kernel import create_ufunc, _Op
 
 
@@ -15,7 +16,7 @@ def _fix_to_sctype(dtype, sctype):
 
 def _s_copy_resolver(op, arginfo):
     # Support only U->S and S->U casts right now
-    sctype = op.in_type[0]
+    sctype = op.in_types[0]
 
     in_dtype = _fix_to_sctype(arginfo[0].dtype, sctype)
     out_dtype = in_dtype  # could call _fix_to_sctype just to sanity check

--- a/cupy/_core/_ufuncs.py
+++ b/cupy/_core/_ufuncs.py
@@ -4,6 +4,6 @@ from cupy._core._kernel import create_ufunc
 elementwise_copy = create_ufunc(
     'cupy_copy',
     ('?->?', 'b->b', 'B->B', 'h->h', 'H->H', 'i->i', 'I->I', 'l->l', 'L->L',
-     'q->q', 'Q->Q', 'e->e', 'f->f', 'd->d', 'F->F', 'D->D'),
+     'q->q', 'Q->Q', 'e->e', 'f->f', 'd->d', 'F->F', 'D->D', 'S->S', 'U->U'),
     'out0 = in0',
     default_casting='unsafe')

--- a/cupy/_core/_ufuncs.py
+++ b/cupy/_core/_ufuncs.py
@@ -14,11 +14,11 @@ def _fix_to_sctype(dtype, sctype):
 
     return np.dtype((sctype, length))
 
-def _s_copy_resolver(op, arginfo):
+def _s_copy_resolver(op, in_dtypes, out_dtypes):
     # Support only U->S and S->U casts right now
     sctype = op.in_types[0]
 
-    in_dtype = _fix_to_sctype(arginfo[0].dtype, sctype)
+    in_dtype = _fix_to_sctype(in_dtypes[0], sctype)
     out_dtype = in_dtype  # could call _fix_to_sctype just to sanity check
 
     return (in_dtype,), (out_dtype,)

--- a/cupy/_core/_ufuncs.py
+++ b/cupy/_core/_ufuncs.py
@@ -21,7 +21,7 @@ def _s_copy_resolver(op, arginfo):
     in_dtype = _fix_to_sctype(arginfo[0].dtype, sctype)
     out_dtype = in_dtype  # could call _fix_to_sctype just to sanity check
 
-    return in_dtype, out_dtype
+    return (in_dtype,), (out_dtype,)
 
 
 elementwise_copy = create_ufunc(

--- a/cupy/_core/_ufuncs.py
+++ b/cupy/_core/_ufuncs.py
@@ -14,6 +14,7 @@ def _fix_to_sctype(dtype, sctype):
 
     return np.dtype((sctype, length))
 
+
 def _s_copy_resolver(op, in_dtypes, out_dtypes):
     # The result must have the same length as the input (it may be cast
     # after the copy no-op)

--- a/cupy/_core/_ufuncs.py
+++ b/cupy/_core/_ufuncs.py
@@ -17,8 +17,8 @@ def _fix_to_sctype(dtype, sctype):
 def _s_copy_resolver(op, in_dtypes, out_dtypes):
     # The result must have the same length as the input (it may be cast
     # after the copy no-op)
-    sctype = op.in_types[0]
-    return (in_dtype,), (in_dtype,)
+    return in_dtypes, in_dtypes
+
 
 elementwise_copy = create_ufunc(
     'cupy_copy',

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -2096,6 +2096,7 @@ cdef list cupy_header_list = [
     'cupy/carray.cuh',
     'cupy/atomics.cuh',
     'cupy/math_constants.h',
+    'cupy/numpystring.h',
 ]
 if _is_hip:
     cupy_header_list.append('cupy/hip_workaround.cuh')
@@ -2471,7 +2472,7 @@ cdef _ndarray_base _array_from_nested_numpy_sequence(
         arrays, src_dtype, dst_dtype, const shape_t& shape, order,
         Py_ssize_t ndmin):
     a_dtype = get_dtype(dst_dtype)  # convert to numpy.dtype
-    if a_dtype.char not in '?bhilqBHILQefdFD':
+    if a_dtype.char not in '?bhilqBHILQefdFDUS':
         raise ValueError('Unsupported dtype %s' % a_dtype)
     cdef _ndarray_base a  # allocate it after pinned memory is secured
     cdef size_t itemcount = internal.prod(shape)
@@ -2530,7 +2531,7 @@ cdef _ndarray_base _array_default(obj, dtype, order, Py_ssize_t ndmin):
             order = 'C'
     a_cpu = numpy.array(obj, dtype=dtype, copy=False, order=order,
                         ndmin=ndmin)
-    if a_cpu.dtype.char not in '?bhilqBHILQefdFD':
+    if a_cpu.dtype.char not in '?bhilqBHILQefdFDUS':
         raise ValueError('Unsupported dtype %s' % a_cpu.dtype)
     a_cpu = a_cpu.astype(a_cpu.dtype.newbyteorder('<'), copy=False)
     a_dtype = a_cpu.dtype

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -2097,7 +2097,6 @@ cdef list cupy_header_list = [
     'cupy/carray.cuh',
     'cupy/atomics.cuh',
     'cupy/math_constants.h',
-    'cupy/numpystring.h',
 ]
 if _is_hip:
     cupy_header_list.append('cupy/hip_workaround.cuh')

--- a/cupy/_core/core.pyx
+++ b/cupy/_core/core.pyx
@@ -566,6 +566,7 @@ cdef class _ndarray_base:
         order_char = internal._update_order_char(
             self._c_contiguous, self._f_contiguous, order_char)
 
+        dtype = _dtype._resolve_dtype_cast(self.dtype, dtype)
         if order_char == b'K':
             strides = internal._get_strides_for_order_K(self, dtype)
             newarray = _ndarray_init(ndarray, self._shape, dtype, None)

--- a/cupy/_core/include/cupy/numpystring.h
+++ b/cupy/_core/include/cupy/numpystring.h
@@ -18,7 +18,7 @@ integer_to_string(const IntT value, CharT *ptr_orig)
         digits[digits_idx++] = '0' + absval % (IntT)10;
         // next digit
         absval = absval / (IntT)10;
-    } while (absval != 0)
+    } while (absval != 0);
 
     CharT *ptr = ptr_orig;
     if (is_negative) {

--- a/cupy/_core/include/cupy/numpystring.h
+++ b/cupy/_core/include/cupy/numpystring.h
@@ -29,7 +29,7 @@ public:
     template<typename OT, int Olen>
     __host__ __device__ NumPyString& operator=(const NumPyString<OT, Olen> &other)
     {
-        // TODO: This is very unsafe (as it just casts)
+        // NOTE: Unlike NumPy, we just cast U->S (unsafe).
         for (int i = 0; i < this->maxlen; i++) {
             this->data[i] = other[i];
         }

--- a/cupy/_core/include/cupy/numpystring.h
+++ b/cupy/_core/include/cupy/numpystring.h
@@ -3,12 +3,12 @@
 
 
 /* The code below is heavily inspired by the cuDF version */
-template<int maxlen, typename IntT, typename CharT>
+template<typename IntT, typename CharT>
 __host__ __device__ void
-integer_to_string(const IntT value, CharT *ptr_orig)
+integer_to_string(const IntT value, int strlen, CharT *ptr_orig)
 {
     /* create temporary char string to flip later */
-    char digits[maxlen];
+    char digits[cuda::std::numeric_limits<IntT>::digits10];
 
     bool const is_negative = value < 0;
     IntT absval = is_negative ? -value : value;
@@ -25,12 +25,12 @@ integer_to_string(const IntT value, CharT *ptr_orig)
         *ptr++ = '-';
     }
     // digits are backwards, reverse the string into the output
-    while (digits_idx-- > 0) {
+    while (digits_idx-- > 0 && strlen-- > 0) {
         *ptr++ = digits[digits_idx];
     }
 
     /* zero fill unused chunk */
-    for (; ptr < ptr_orig + maxlen; ptr++) {
+    for (; ptr < ptr_orig + strlen; ptr++) {
         *ptr = 0;
     }
 }
@@ -84,7 +84,7 @@ public:
     // TODO: Howto template it for all integers?!
     __host__ __device__ NumPyString& operator=(const long &value)
     {
-        integer_to_string<maxlen_>(value, this->data);
+        integer_to_string(value, maxlen_, this->data);
         return *this;
     }
 

--- a/cupy/_core/include/cupy/numpystring.h
+++ b/cupy/_core/include/cupy/numpystring.h
@@ -2,10 +2,11 @@
 #define CUPY_NUMPYSTRING_H
 
 
-template<typename T, int maxlen>
+template<typename T, int maxlen_>
 class NumPyString {
 public:
-    T data[maxlen];
+    static const int maxlen = maxlen_;
+    T data[maxlen_];
 
     __host__ __device__ int strlen() {
         int len = maxlen;
@@ -15,30 +16,30 @@ public:
         return len;
     }
 
-    __host__ __device__ T operator[](int i){
+    __host__ __device__ T operator[](int i) const {
         /* Allowing too large `i` for easier handling of different length */
-        if (i < this.maxlen) {
-            return this.data[i];
+        if (i < this->maxlen) {
+            return this->data[i];
         }
         return 0;
     }
 
-    __host__ __device__ NumPyString& operator=(NumPyString &other)
+    template<typename OT, int Olen>
+    __host__ __device__ NumPyString& operator=(const NumPyString<OT, Olen> &other)
     {
-        // For now don't allow, we should error if not ascii/latin1, or
-        // should it simply cast and don't worry about it?
-        static_assert(sizeof(this.T) >= sizeof(other.T));
-        for (int i = 0; i < this.maxlen; i++) {
-            this.data[i] = other[i];
+        // TODO: This is very unsafe (as it just casts)
+        for (int i = 0; i < this->maxlen; i++) {
+            this->data[i] = other[i];
         }
-        return this;
+        return *this;
     }
 
-    __host__ __device__ bool operator==(NumPyString &other)
+    template<typename OT, int Olen>
+    __host__ __device__ bool operator==(const NumPyString<OT, Olen> &other)
     {
-        int longer = this.maxlen > other.maxlen ? this.maxlen : other.maxlen;
+        int longer = this->maxlen > other->maxlen ? this->maxlen : other->maxlen;
         for (int i = 0; i < longer; i++) {
-            if (this->data[i] != other.data[i]) {
+            if (this->data[i] != other->data[i]) {
                 return false;
             }
         }

--- a/cupy/_core/include/cupy/numpystring.h
+++ b/cupy/_core/include/cupy/numpystring.h
@@ -48,6 +48,24 @@ public:
     }
 
     template<typename OT, int Olen>
+    __host__ __device__ NumPyString& operator=(const double &other)
+    {
+        /* create temporary char string, since we may have a unicode one */
+        const NumPyString<char, this->maxlen> charstr;
+        const char *end = charstr.data + this->maxlen;
+
+        std::to_chars_result res;
+        res = std::to_chars(charstr.data, end, other);
+        /* zero fill unused chunk */
+        for (char *ptr = res.ptr; ptr < end; ptr++) {
+            ptr[i] = 0;
+        }
+
+        *this = charstr;
+        return *this;
+    }
+
+    template<typename OT, int Olen>
     __host__ __device__ bool operator==(const NumPyString<OT, Olen> &other) const
     {
         int longer = this->maxlen > other.maxlen ? this->maxlen : other.maxlen;

--- a/cupy/_core/include/cupy/numpystring.h
+++ b/cupy/_core/include/cupy/numpystring.h
@@ -24,6 +24,7 @@ integer_to_string(const IntT value, int strlen, CharT *ptr_orig)
     CharT *ptr = ptr_orig;
     if (is_negative) {
         *ptr++ = '-';
+        strlen--;
     }
     // digits are backwards, reverse the string into the output
     while (digits_idx-- > 0 && strlen-- > 0) {
@@ -31,8 +32,8 @@ integer_to_string(const IntT value, int strlen, CharT *ptr_orig)
     }
 
     /* zero fill unused chunk */
-    for (; ptr < ptr_orig + strlen; ptr++) {
-        *ptr = 0;
+    while (strenlen--) {
+        *ptr++ = 0;
     }
 }
 

--- a/cupy/_core/include/cupy/numpystring.h
+++ b/cupy/_core/include/cupy/numpystring.h
@@ -1,0 +1,50 @@
+#ifndef CUPY_NUMPYSTRING_H
+#define CUPY_NUMPYSTRING_H
+
+
+template<typename T, int maxlen>
+class NumPyString {
+public:
+    T data[maxlen];
+
+    __host__ __device__ int strlen() {
+        int len = maxlen;
+        while (len > 0 && this->data[len-1] == 0) {
+            len--;
+        }
+        return len;
+    }
+
+    __host__ __device__ T operator[](int i){
+        /* Allowing too large `i` for easier handling of different length */
+        if (i < this.maxlen) {
+            return this.data[i];
+        }
+        return 0;
+    }
+
+    __host__ __device__ NumPyString& operator=(NumPyString &other)
+    {
+        // For now don't allow, we should error if not ascii/latin1, or
+        // should it simply cast and don't worry about it?
+        static_assert(sizeof(this.T) >= sizeof(other.T));
+        for (int i = 0; i < this.maxlen; i++) {
+            this.data[i] = other[i];
+        }
+        return this;
+    }
+
+    __host__ __device__ bool operator==(NumPyString &other)
+    {
+        int longer = this.maxlen > other.maxlen ? this.maxlen : other.maxlen;
+        for (int i = 0; i < longer; i++) {
+            if (this->data[i] != other.data[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+};
+
+
+#endif  // CUPY_NUMPYSTRING_H

--- a/cupy/_core/include/cupy/numpystring.h
+++ b/cupy/_core/include/cupy/numpystring.h
@@ -6,7 +6,9 @@ template<typename T, int maxlen_>
 class NumPyString {
 public:
     static const int maxlen = maxlen_;
-    T data[maxlen_];
+    // TODO: 0 is possible, but C doesn't like it here (for good reasons)
+    //       there may be a way to tell C++ that empty is OK/possible?
+    T data[maxlen_ ? maxlen_ : 1];
 
     __host__ __device__ int strlen() {
         int len = maxlen;

--- a/cupy/_core/include/cupy/numpystring.h
+++ b/cupy/_core/include/cupy/numpystring.h
@@ -18,6 +18,17 @@ public:
         return len;
     }
 
+    __host__ __device__ NumPyString () {}
+
+    template<typename OT, int Olen>
+    __host__ __device__ NumPyString (const NumPyString<OT, Olen> &other)
+    {
+        // TODO: This is very unsafe (as it just casts)
+        for (int i = 0; i < this->maxlen; i++) {
+            this->data[i] = other[i];
+        }
+    }
+
     __host__ __device__ T operator[](int i) const {
         /* Allowing too large `i` for easier handling of different length */
         if (i < this->maxlen) {
@@ -37,11 +48,11 @@ public:
     }
 
     template<typename OT, int Olen>
-    __host__ __device__ bool operator==(const NumPyString<OT, Olen> &other)
+    __host__ __device__ bool operator==(const NumPyString<OT, Olen> &other) const
     {
-        int longer = this->maxlen > other->maxlen ? this->maxlen : other->maxlen;
+        int longer = this->maxlen > other.maxlen ? this->maxlen : other.maxlen;
         for (int i = 0; i < longer; i++) {
-            if (this->data[i] != other->data[i]) {
+            if ((*this)[i] != other[i]) {
                 return false;
             }
         }


### PR DESCRIPTION
Note, that the main point of string support may be general support for parametric dtypes, which includes supporting structured DTypes.

None of these changes are particularly huge and many still a bit draft, they seperate into:

1. Creation of a `numpystring.h` header implementing a class to represent the NumPy string dtype (with its length parameter).  This is very much in a draft/proof-of-concept stage.
2. Reorganize things, so that getting the C-name can also provide additional header files that are required (I am not sure about this).
3. We need to modify some code to propagate `dtype` rather than the `dtype.type`.
4. Implement `resolve_dtypes` and move it onto the `_Op`.  Parametric DTypes, unlike most, may need to figure out the correct dtype instance to use.
5. Casting is (currently) special:  We need a place to define that `int32 -> string` gives a length 22 string, define that place.